### PR TITLE
Add anchors to images

### DIFF
--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -12,7 +12,7 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! success
     If your output looks something like this image, you are all set:
 
-[![docker-info](../images/docker-info.png "docker info")](/git-foundations/images/docker-info.png){target=_blank}
+[![docker-info](../images/docker-info.png "docker info")](/git-foundations/images/docker-info.png){target=_blank}d
 
 ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -12,11 +12,11 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! success
     If your output looks something like this image, you are all set:
 
-![docker-info](../images/docker-info.png "docker info")(https://raw.githubusercontent.com/wwt/git-foundations/main/docs/images/docker-info.png)
+![docker-info](../images/docker-info.png "docker info")(../images/docker-info.png)
 
-![docker-info](../images/docker-info.png "docker info"){target=_blank}(https://raw.githubusercontent.com/wwt/git-foundations/main/docs/images/docker-info.png)
+![docker-info](../images/docker-info.png "docker info"){target=_blank}(../images/docker-info.png)
 
-![docker-info](../images/docker-info.png "docker info")(https://raw.githubusercontent.com/wwt/git-foundations/main/docs/images/docker-info.png)
+![docker-info](../images/docker-info.png "docker info")(..images/docker-info.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -12,9 +12,7 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! success
     If your output looks something like this image, you are all set:
 
-[![docker-info](../images/docker-info.png "docker info")](/images/docker-info.png){target=_blank}
-
-[![docker-info](../images/docker-info.png "docker info")](https://wwt.github.io/git-foundations/images/docker-info.png){target=_blank}
+[![docker-info](../images/docker-info.png "docker info")](/git-foundations/images/docker-info.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -19,7 +19,7 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! failure
      If you see an error message similiar to the example below, make sure you installed Docker Desktop and that Docker Desktop is running.  You may also review the [Docker Desktop Installation Documentation](https://docs.docker.com/desktop/ "Docker Desktop Installation Documentation"){target=_blank}.
 
-[![docker-info-bad](../images/docker-info-bad.png "docker info - Docker not running")]/git-foundations/images/docker-info-bad.png){target=_blank}
+[![docker-info-bad](../images/docker-info-bad.png "docker info - Docker not running")](/git-foundations/images/docker-info-bad.png){target=_blank}
 
 ---
 
@@ -41,7 +41,7 @@ There are two-steps in the process (download and then run) to create the Docker 
 
     You will know your Docker Container environment is ready for the Git hands-on exercises when your terminal prompt changes to `/development#`:
 
-    [![docker-container-run](../images/docker-container-run.png "docker container run -it --name git-foundations wwt01/alpine-network-dev")]/git-foundations/images/docker-container-run.png){target=_blank}
+    [![docker-container-run](../images/docker-container-run.png "docker container run -it --name git-foundations wwt01/alpine-network-dev")](/git-foundations/images/docker-container-run.png){target=_blank}
 
     ---
 
@@ -57,7 +57,7 @@ There are two-steps in the process (download and then run) to create the Docker 
 
 3. You are in the Docker Container environment if your output looks like this:
 
-    [![container-release-info](../images/container-release-info.png "cat /etc/*-release")]/git-foundations/images/container-release-info.png){target=_blank}
+    [![container-release-info](../images/container-release-info.png "cat /etc/*-release")](/git-foundations/images/container-release-info.png){target=_blank}
 
     ---
 
@@ -69,7 +69,7 @@ There are two-steps in the process (download and then run) to create the Docker 
 
     The result of that command should look something like this:
 
-    [![git-version](../images/git-version.png "git --version")]/git-foundations/images/git-version.png){target=_blank}
+    [![git-version](../images/git-version.png "git --version")](/git-foundations/images/git-version.png){target=_blank}
 
     ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -12,11 +12,11 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! success
     If your output looks something like this image, you are all set:
 
-![docker-info](../images/docker-info.png "docker info")(../images/docker-info.png)
+[![docker-info](../images/docker-info.png "docker info")](../images/docker-info.png)
 
-![docker-info](../images/docker-info.png "docker info"){target=_blank}(../images/docker-info.png)
+[![docker-info](../images/docker-info.png "docker info"){target=_blank}](../images/docker-info.png)
 
-![docker-info](../images/docker-info.png "docker info")(..images/docker-info.png){target=_blank}
+[![docker-info](../images/docker-info.png "docker info")](..images/docker-info.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -16,6 +16,8 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 
 [![docker-info](../images/docker-info.png "docker info")](images/docker-info.png){target=_blank}
 
+[![docker-info](../images/docker-info.png "docker info")](images/docker-info.png){target=_blank}
+
 ---
 
 !!! failure

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -12,7 +12,11 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! success
     If your output looks something like this image, you are all set:
 
+![docker-info](../images/docker-info.png "docker info")(https://raw.githubusercontent.com/wwt/git-foundations/main/docs/images/docker-info.png)
+
 ![docker-info](../images/docker-info.png "docker info"){target=_blank}(https://raw.githubusercontent.com/wwt/git-foundations/main/docs/images/docker-info.png)
+
+![docker-info](../images/docker-info.png "docker info")(https://raw.githubusercontent.com/wwt/git-foundations/main/docs/images/docker-info.png)
 
 ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -19,7 +19,7 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! failure
      If you see an error message similiar to the example below, make sure you installed Docker Desktop and that Docker Desktop is running.  You may also review the [Docker Desktop Installation Documentation](https://docs.docker.com/desktop/ "Docker Desktop Installation Documentation"){target=_blank}.
 
-![docker-info-bad](../images/docker-info-bad.png "docker info - Docker not running")
+![docker-info-bad](../images/docker-info-bad.png "docker info - Docker not running")/git-foundations/images/docker-info-bad.png){target=_blank}
 
 ---
 
@@ -41,7 +41,7 @@ There are two-steps in the process (download and then run) to create the Docker 
 
     You will know your Docker Container environment is ready for the Git hands-on exercises when your terminal prompt changes to `/development#`:
 
-    ![docker-container-run](../images/docker-container-run.png "docker container run -it --name git-foundations wwt01/alpine-network-dev")
+    ![docker-container-run](../images/docker-container-run.png "docker container run -it --name git-foundations wwt01/alpine-network-dev")/git-foundations/images/docker-container-run.png){target=_blank}
 
     ---
 
@@ -57,7 +57,7 @@ There are two-steps in the process (download and then run) to create the Docker 
 
 3. You are in the Docker Container environment if your output looks like this:
 
-    ![container-release-info](../images/container-release-info.png "cat /etc/*-release")
+    ![container-release-info](../images/container-release-info.png "cat /etc/*-release")/git-foundations/images/container-release-info.png){target=_blank}
 
     ---
 
@@ -69,7 +69,7 @@ There are two-steps in the process (download and then run) to create the Docker 
 
     The result of that command should look something like this:
 
-    ![git-version](../images/git-version.png "git --version")
+    ![git-version](../images/git-version.png "git --version")/git-foundations/images/git-version.png){target=_blank}
 
     ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -12,11 +12,9 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! success
     If your output looks something like this image, you are all set:
 
-[![docker-info](../images/docker-info.png "docker info")](../images/docker-info.png)
+[![docker-info](../images/docker-info.png "docker info")](/images/docker-info.png){target=_blank}
 
-[![docker-info](../images/docker-info.png "docker info")](images/docker-info.png){target=_blank}
-
-[![docker-info](../images/docker-info.png "docker info")](images/docker-info.png){target=_blank}
+[![docker-info](../images/docker-info.png "docker info")](https://wwt.github.io/git-foundations/images/docker-info.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -12,7 +12,7 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! success
     If your output looks something like this image, you are all set:
 
-![docker-info](../images/docker-info.png "docker info")(https://raw.githubusercontent.com/wwt/git-foundations/main/docs/images/docker-info.png){target=_blank}
+![docker-info](../images/docker-info.png "docker info"){target=_blank}(https://raw.githubusercontent.com/wwt/git-foundations/main/docs/images/docker-info.png)
 
 ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -12,7 +12,7 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! success
     If your output looks something like this image, you are all set:
 
-![docker-info](../images/docker-info.png "docker info")
+![docker-info](../images/docker-info.png "docker info")(https://raw.githubusercontent.com/wwt/git-foundations/main/docs/images/docker-info.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -14,9 +14,7 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 
 [![docker-info](../images/docker-info.png "docker info")](../images/docker-info.png)
 
-[![docker-info](../images/docker-info.png "docker info"){target=_blank}](../images/docker-info.png)
-
-[![docker-info](../images/docker-info.png "docker info")](..images/docker-info.png){target=_blank}
+[![docker-info](../images/docker-info.png "docker info")](images/docker-info.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_1.md
+++ b/docs/sections/section_1.md
@@ -12,14 +12,14 @@ A WWT-built Docker Image provides a ready-to-use environment for the Git hands-o
 !!! success
     If your output looks something like this image, you are all set:
 
-[![docker-info](../images/docker-info.png "docker info")](/git-foundations/images/docker-info.png){target=_blank}d
+[![docker-info](../images/docker-info.png "docker info")](/git-foundations/images/docker-info.png){target=_blank}
 
 ---
 
 !!! failure
      If you see an error message similiar to the example below, make sure you installed Docker Desktop and that Docker Desktop is running.  You may also review the [Docker Desktop Installation Documentation](https://docs.docker.com/desktop/ "Docker Desktop Installation Documentation"){target=_blank}.
 
-![docker-info-bad](../images/docker-info-bad.png "docker info - Docker not running")/git-foundations/images/docker-info-bad.png){target=_blank}
+[![docker-info-bad](../images/docker-info-bad.png "docker info - Docker not running")]/git-foundations/images/docker-info-bad.png){target=_blank}
 
 ---
 
@@ -41,7 +41,7 @@ There are two-steps in the process (download and then run) to create the Docker 
 
     You will know your Docker Container environment is ready for the Git hands-on exercises when your terminal prompt changes to `/development#`:
 
-    ![docker-container-run](../images/docker-container-run.png "docker container run -it --name git-foundations wwt01/alpine-network-dev")/git-foundations/images/docker-container-run.png){target=_blank}
+    [![docker-container-run](../images/docker-container-run.png "docker container run -it --name git-foundations wwt01/alpine-network-dev")]/git-foundations/images/docker-container-run.png){target=_blank}
 
     ---
 
@@ -57,7 +57,7 @@ There are two-steps in the process (download and then run) to create the Docker 
 
 3. You are in the Docker Container environment if your output looks like this:
 
-    ![container-release-info](../images/container-release-info.png "cat /etc/*-release")/git-foundations/images/container-release-info.png){target=_blank}
+    [![container-release-info](../images/container-release-info.png "cat /etc/*-release")]/git-foundations/images/container-release-info.png){target=_blank}
 
     ---
 
@@ -69,7 +69,7 @@ There are two-steps in the process (download and then run) to create the Docker 
 
     The result of that command should look something like this:
 
-    ![git-version](../images/git-version.png "git --version")/git-foundations/images/git-version.png){target=_blank}
+    [![git-version](../images/git-version.png "git --version")]/git-foundations/images/git-version.png){target=_blank}
 
     ---
 

--- a/docs/sections/section_10.md
+++ b/docs/sections/section_10.md
@@ -11,7 +11,7 @@ Let's take a look at how the changes we pushed from our local Git repository imp
     - The GitHub repository now has three branches, up from two before we pushed **branch3** from our local Git repository to GitHub.
     - There is a highlighted message indicating a recently pushed branch (**branch3**).
 
-    ![github-repo-push-review](../images/github-repo-push-review.png "Review local repository changes in GitHub")
+    [![github-repo-push-review](../images/github-repo-push-review.png "Review local repository changes in GitHub")](/git-foundations/images/github-repo-push-review.png){target=_blank}
 
     ---
 
@@ -19,7 +19,7 @@ Let's take a look at how the changes we pushed from our local Git repository imp
 
 3. Click on **branch3**:
 
-    ![github-repo-push-branch-list](../images/github-repo-push-branch-list.png "Switch to branch 'branch3'")
+    [![github-repo-push-branch-list](../images/github-repo-push-branch-list.png "Switch to branch 'branch3'")](/git-foundations/images/github-repo-push-branch-list.png){target=_blank}
 
     ---
 
@@ -28,7 +28,7 @@ Let's take a look at how the changes we pushed from our local Git repository imp
 
 5. Click on the **3 commits** link to review the individual commits.
 
-    ![github-repo-branch3-review](../images/github-repo-branch3-review.png "Review branch 'branch3'")
+    [![github-repo-branch3-review](../images/github-repo-branch3-review.png "Review branch 'branch3'")](/git-foundations/images/github-repo-branch3-review.png){target=_blank}
 
     ---
 
@@ -37,7 +37,7 @@ Let's take a look at how the changes we pushed from our local Git repository imp
     - We can also see the two atomic commits from our local Git repository along with the messages we added with the `git commit -m` commands.
     - Even though the `git push` command sent all of our local repository to GitHub at once, the individual atomic commits remain separate and reviewable.
 
-    ![github-repo-branch3-commits](../images/github-repo-branch3-commits.png "Review branch 'branch3' commits")
+    [![github-repo-branch3-commits](../images/github-repo-branch3-commits.png "Review branch 'branch3' commits")](/git-foundations/images/github-repo-branch3-commits.png){target=_blank}
 
 7. Click the **git-repo-1** link at the top of the window to return to the repository home page.
 

--- a/docs/sections/section_11.md
+++ b/docs/sections/section_11.md
@@ -8,7 +8,7 @@ A **pull request** is GitHub's terminology for starting the process to merge cha
 
 1. Locate and click the green **Compare & pull request** button:
 
-    ![github-pull-request-initiate](../images/github-pull-request-initiate.png "Initiate pull request")
+    [![github-pull-request-initiate](../images/github-pull-request-initiate.png "Initiate pull request")](/git-foundations/images/github-pull-request-initiate.png){target=_blank}
 
 2. Add the following details to the **pull request**:
     - **Title - _Branch3_**
@@ -19,7 +19,7 @@ A **pull request** is GitHub's terminology for starting the process to merge cha
 
 3. Click the green **Create pull request** button:
 
-    ![github-pull-request-open](../images/github-pull-request-open.png "Create pull request")
+    [![github-pull-request-open](../images/github-pull-request-open.png "Create pull request")](/git-foundations/images/github-pull-request-open.png){target=_blank}
 
 ---
 
@@ -27,7 +27,7 @@ A **pull request** is GitHub's terminology for starting the process to merge cha
 
 1. Review the details of the **pull request** and then click the green **Merge pull request** button:
 
-    ![github-pull-request-merge](../images/github-pull-request-merge.png "Merge pull request")
+    [![github-pull-request-merge](../images/github-pull-request-merge.png "Merge pull request")](/git-foundations/images/github-pull-request-merge.png){target=_blank}
 
     ---
 
@@ -35,7 +35,7 @@ A **pull request** is GitHub's terminology for starting the process to merge cha
 
 3. Click the green **Confirm merge** button to complete the **pull request**.
 
-    ![github-pull-request-merge-confirm](../images/github-pull-request-merge-confirm.png "Confirm pull request merge")
+    [![github-pull-request-merge-confirm](../images/github-pull-request-merge-confirm.png "Confirm pull request merge")](/git-foundations/images/github-pull-request-merge-confirm.png){target=_blank}
 
 ---
 
@@ -45,19 +45,19 @@ A **pull request** is GitHub's terminology for starting the process to merge cha
 
 2. In some cases, you may want to retain branches after you merge their changes into the **main** branch, or any other branch. In this case, we will remove **branch3** to keep from cluttering the repository with a history of every branch. Click the **Delete branch** button to remove **branch3** from GitHub.
 
-    ![github-pull-branch-delete](../images/github-pull-branch-delete.png "Delete branch 'branch3'")
+    [![github-pull-branch-delete](../images/github-pull-branch-delete.png "Delete branch 'branch3'")](/git-foundations/images/github-pull-branch-delete.png){target=_blank}
 
     ---
 
 3. Click the **git-repo-1** link at the top of the window to return to the repository home page.
 
-    ![github-pull-branch-delete-done](../images/github-pull-branch-delete-done.png "Return to repository home page")
+    [![github-pull-branch-delete-done](../images/github-pull-branch-delete-done.png "Return to repository home page")](/git-foundations/images/github-pull-branch-delete-done.png){target=_blank}
 
     ---
 
 4. Notice the message which indicates the merge of the **pull request**.
 
-    ![github-pull-request-complete](../images/github-pull-request-complete.png "Review pull request success message")
+    [![github-pull-request-complete](../images/github-pull-request-complete.png "Review pull request success message")](/git-foundations/images/github-pull-request-complete.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_12.md
+++ b/docs/sections/section_12.md
@@ -13,7 +13,7 @@ The GitHub repository has a new version of the **main** branch but the **main** 
     git pull
     ```
 
-    ![git-pull-branch3](../images/git-pull-branch3.png "Pull branch3 from GitHub")
+    [![git-pull-branch3](../images/git-pull-branch3.png "Pull branch3 from GitHub")](/git-foundations/images/git-pull-branch3.png){target=_blank}
 
 2. Notice the last two lines of the output which indicate Git attempted to pull changes from GitHub and merge those changes with **branch3** in the local Git repository.
 
@@ -28,7 +28,7 @@ The GitHub repository has a new version of the **main** branch but the **main** 
     git branch
     ```
 
-    ![git-branch-6](../images/git-branch-6.png "Display local git branches")
+    [![git-branch-6](../images/git-branch-6.png "Display local git branches")](/git-foundations/images/git-branch-6.png){target=_blank}
 
 4. Notice **branch3** remains in your local repository and is the current, working branch.
 
@@ -41,7 +41,7 @@ The GitHub repository has a new version of the **main** branch but the **main** 
     git checkout main
     ```
 
-    ![git-checkout-main](../images/git-checkout-main.png "Switch to branch 'main'")
+    [![git-checkout-main](../images/git-checkout-main.png "Switch to branch 'main'")](/git-foundations/images/git-checkout-main.png){target=_blank}
 
 6. Notice the message which indicates the local Git repository branch **main** is behind the GitHub **main** branch (**origin/main**) by three commits and can be fast-forwarded (synchronized with the latest changes).
 
@@ -54,7 +54,7 @@ The GitHub repository has a new version of the **main** branch but the **main** 
     git pull
     ```
 
-    ![git-pull-main](../images/git-pull-main.png "Pull the branch 'main' from GitHub and merge changes with the local branch 'main'")
+    [![git-pull-main](../images/git-pull-main.png "Pull the branch 'main' from GitHub and merge changes with the local branch 'main'")](/git-foundations/images/git-pull-main.png){target=_blank}
 
 8. Notice the output which indicates the file changes and insertions.
 
@@ -67,7 +67,7 @@ The GitHub repository has a new version of the **main** branch but the **main** 
     git branch -d branch3
     ```
 
-    ![git-branch-d-branch3](../images/git-branch-d-branch3.png "Delete branch 'branch3'")
+    [![git-branch-d-branch3](../images/git-branch-d-branch3.png "Delete branch 'branch3'")](/git-foundations/images/git-branch-d-branch3.png){target=_blank}
 
     ---
 
@@ -78,7 +78,7 @@ The GitHub repository has a new version of the **main** branch but the **main** 
     git branch
     ```
 
-    ![git-branch-7](../images/git-branch-7.png "Display local branches")
+    [![git-branch-7](../images/git-branch-7.png "Display local branches")](/git-foundations/images/git-branch-7.png){target=_blank}
 
 11. Notice that **main** is now the only branch in your local Git repository.
 

--- a/docs/sections/section_2.md
+++ b/docs/sections/section_2.md
@@ -60,7 +60,7 @@ Before we setup a GitHub repository, it's a good idea to consider how our local 
 
 1. Navigate to [https://github.com/login](https://github.com/login "GitHub Login"){target=_blank}, log in, click the **Profile** icon in the upper-right corner of the window, and choose **Settings**.
 
-    [![github-settings](../images/github-settings.png "GitHub settings access")](/git-foundations/images/github-settings){target=_blank}
+    [![github-settings](../images/github-settings.png "GitHub settings access")](/git-foundations/images/github-settings.png){target=_blank}
 
     ---
 

--- a/docs/sections/section_2.md
+++ b/docs/sections/section_2.md
@@ -36,7 +36,7 @@ Before we setup a GitHub repository, it's a good idea to consider how our local 
 
 2. After you enter this command and press your ++enter++ or ++"Return"++ key, you may press your ++enter++ or ++"Return"++ key **three more times**, to accept the default storage location for the key and to accept and confirm the default, blank passphrase. Your terminal output will look something like this:
 
-    ![container-ssh-keygen](../images/container-ssh-keygen.png "ssh-keygen")
+    [![container-ssh-keygen](../images/container-ssh-keygen.png "ssh-keygen")](/git-foundations/images/container-ssh-keygen.png){target=_blank}
 
     ---
 
@@ -50,7 +50,7 @@ Before we setup a GitHub repository, it's a good idea to consider how our local 
     !!! caution
         Treat your SSH keys as if they were any other form of credentials and do not share them with anyone.
 
-    ![container-ssh-key](../images/container-ssh-key.png "cat ~/.ssh/id_rsa.pub")
+    [![container-ssh-key](../images/container-ssh-key.png "cat ~/.ssh/id_rsa.pub")](/git-foundations/images/container-ssh-key.png){target=_blank}
 
 4. Copy the full contents of the SSH public key output to your clipboard, including the **ssh-rsa** at the beginning of the file and the **root@_container_id_** at the end of the file. We will share the text from this file with GitHub to establish mutual trust between our Container and GitHub.
 
@@ -60,31 +60,31 @@ Before we setup a GitHub repository, it's a good idea to consider how our local 
 
 1. Navigate to [https://github.com/login](https://github.com/login "GitHub Login"){target=_blank}, log in, click the **Profile** icon in the upper-right corner of the window, and choose **Settings**.
 
-    ![github-settings](../images/github-settings.png "GitHub settings access")
+    [![github-settings](../images/github-settings.png "GitHub settings access")](/git-foundations/images/github-settings){target=_blank}
 
     ---
 
 2. Click on the **SSH and GPG keys** tab on the left side of the window.
 
-    ![github-profile](../images/github-profile.png "GitHub profile")
+    [![github-profile](../images/github-profile.png "GitHub profile")](/git-foundations/images/github-profile.png){target=_blank}
 
     ---
 
 3. Click the green, **New SSH key** button
 
-    ![github-ssh-keys](../images/github-ssh-keys.png "GitHub SSH keys")
+    [![github-ssh-keys](../images/github-ssh-keys.png "GitHub SSH keys")](/git-foundations/images/github-ssh-keys.png){target=_blank}
 
     ---
 
 4. Provide a title for the SSH key (any title you like is just fine), paste the SSH key file text from your Container into the **Key** field, and click the green, **Add SSH key** button.
 
-    ![github-add-ssh-key](../images/github-add-ssh-key.png "GitHub create SSH key")
+    [![github-add-ssh-key](../images/github-add-ssh-key.png "GitHub create SSH key")](/git-foundations/images/github-add-ssh-key.png){target=_blank}
 
     ---
 
 5. Confirm that GitHub now has a copy of your container's SSH public key.
 
-    ![github-new-ssh-key](../images/github-new-ssh-key.png "GitHub new SSH key")
+    [![github-new-ssh-key](../images/github-new-ssh-key.png "GitHub new SSH key")](/git-foundations/images/github-new-ssh-key.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_3.md
+++ b/docs/sections/section_3.md
@@ -10,7 +10,7 @@ You have the option to create Git repositories either on your local machine (wit
 2. The view you see may vary depending on whether or not your GitHub account is new. You should see a green button on the left side of the window which reads either **Create repository**, **New repository**, or something similar.
     - If you don't see the button, navigate to your GitHub home page with click to the GitHub logo in the upper-left corner of any GitHub window.
 
-    ![github-new-repo](../images/github-new-repo.png "Create new repository")
+    [![github-new-repo](../images/github-new-repo.png "Create new repository")](/git-foundations/images/github-new-repo.png){target=_blank}
 
     ---
 
@@ -31,13 +31,13 @@ You have the option to create Git repositories either on your local machine (wit
 
         - Click the **Create repository** button
 
-    ![github-new-repo-details](../images/github-new-repo-details.png "Add new repository details")
+    [![github-new-repo-details](../images/github-new-repo-details.png "Add new repository details")](/git-foundations/images/github-new-repo-details.png){target=_blank}
 
     ---
 
 3. Take a look at your new repository! You have two files, **.gitignore** and **README.md**.
 
-    ![github-new-repo-complete](../images/github-new-repo-complete.png "New repository files")
+   [![github-new-repo-complete](../images/github-new-repo-complete.png "New repository files")](/git-foundations/images/github-new-repo-complete.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_4.md
+++ b/docs/sections/section_4.md
@@ -9,13 +9,13 @@ Before we clone our new repository to our Docker Container, let's create a new b
 
 1. Click the **Branch: main** button to expand the **Branch** drop-down menu. Type the name **branch1** for the new branch and then click the text **Create branch: branch1 from 'main'**.
 
-    ![github-new-branch](../images/github-new-branch.png "Create 'branch1' from 'main'")
+    [![github-new-branch](../images/github-new-branch.png "Create 'branch1' from 'main'")](/git-foundations/images/github-new-branch.png){target=_blank}
 
     ---
 
 2. Click the **Branch: branch1** button to expand the **Branch** drop-down menu. Notice that there are now two branches, **main** and **branch1**.
 
-    ![github-branch-list](../images/github-branch-list.png "List of repository branches")
+    [![github-branch-list](../images/github-branch-list.png "List of repository branches")](/git-foundations/images/github-branch-list.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_5.md
+++ b/docs/sections/section_5.md
@@ -10,13 +10,13 @@ We mentioned GitHub supports two transports, HTTPS and SSH. GitHub defaults to H
 
 1. Click the green **Clone** button and notice that GitHub displays an HTTPS URL. Click the **SSH** link to change the display to an SSH URL.
 
-    ![github-clone-https](../images/github-clone-https.png "Clone repository button default transport")
+    [![github-clone-https](../images/github-clone-https.png "Clone repository button default transport")](/git-foundations/images/github-clone-https.png){target=_blank}
 
     ---
 
 2. Click the **Copy** icon, just to the right of the SSH URL, to store the URL on your clipboard.
 
-    ![github-clone-ssh](../images/github-clone-ssh.png "Copy repository SSH URL")
+    [![github-clone-ssh](../images/github-clone-ssh.png "Copy repository SSH URL")](/git-foundations/images/github-clone-ssh.png){target=_blank}
 
 ---
 
@@ -34,7 +34,7 @@ We mentioned GitHub supports two transports, HTTPS and SSH. GitHub defaults to H
 
     The result of the `git clone` command should look something like this:
 
-    ![git-clone](../images/git-clone.png "Clone GitHub repository")
+    [![git-clone](../images/git-clone.png "Clone GitHub repository")](/git-foundations/images/git-clone.png){target=_blank}
 
     ---
 
@@ -45,7 +45,7 @@ We mentioned GitHub supports two transports, HTTPS and SSH. GitHub defaults to H
     ls -l
     ```
 
-    ![container-root-ls](../images/container-root-ls.png "List directory contents")
+    [![container-root-ls](../images/container-root-ls.png "List directory contents")](/git-foundations/images/container-root-ls.png){target=_blank}
 
     ---
 
@@ -61,7 +61,7 @@ We mentioned GitHub supports two transports, HTTPS and SSH. GitHub defaults to H
     pwd
     ```
 
-    ![container-cd-repo](../images/container-cd-repo.png "Change to the respository directory")
+    [![container-cd-repo](../images/container-cd-repo.png "Change to the respository directory")](/git-foundations/images/container-cd-repo.png){target=_blank}
 
     ---
 
@@ -72,7 +72,7 @@ We mentioned GitHub supports two transports, HTTPS and SSH. GitHub defaults to H
     ls -la
     ```
 
-    ![container-repo-ls](../images/container-repo-ls.png "List all repository files")
+    [![container-repo-ls](../images/container-repo-ls.png "List all repository files")](/git-foundations/images/container-repo-ls.png){target=_blank}
 
 5. Notice that both of the files in your GitHub repository (**.gitignore** and **README.md**) are now in our Docker Container.
 
@@ -85,7 +85,7 @@ We mentioned GitHub supports two transports, HTTPS and SSH. GitHub defaults to H
     cat README.md
     ```
 
-    ![container-cat-readme](../images/container-cat-readme.png "Display the README.md file contents")
+    [![container-cat-readme](../images/container-cat-readme.png "Display the README.md file contents")](/git-foundations/images/container-cat-readme.png){target=_blank}
 
     ---
 
@@ -96,7 +96,7 @@ We mentioned GitHub supports two transports, HTTPS and SSH. GitHub defaults to H
     ls -l .git
     ```
 
-    ![container-ls-git](../images/container-ls-git.png "List the contents of the .git directory")
+    [![container-ls-git](../images/container-ls-git.png "List the contents of the .git directory")](/git-foundations/images/container-ls-git.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_6.md
+++ b/docs/sections/section_6.md
@@ -40,7 +40,7 @@ For the purpose of familiarization with the process to configure different Git c
     # For demonstration purposes, do not replace this email address
     ```
 
-    ![git-config-system](../images/git-config-system.png "Set system-wide git configuration properties")
+    [![git-config-system](../images/git-config-system.png "Set system-wide git configuration properties")](/git-foundations/images/git-config-system.png){target=_blank}
 
     ---
 
@@ -51,7 +51,7 @@ For the purpose of familiarization with the process to configure different Git c
     cat /etc/gitconfig
     ```
 
-    ![container-cat-git-system](../images/container-cat-git-system.png "Review system-wide git configuration")
+    [![container-cat-git-system](../images/container-cat-git-system.png "Review system-wide git configuration")](/git-foundations/images/container-cat-git-system.png){target=_blank}
 
 3. Notice the **name** and **email** values which are part of the Git **system** configuration file. Right now, these settings apply to all Git repositories for all users in our environment.
 
@@ -70,7 +70,7 @@ For the purpose of familiarization with the process to configure different Git c
     # Replace 'your.email@your_domain.com' with your email address
     ```
 
-    ![git-config-global](../images/git-config-global.png "Set global git configuration properties")
+    [![git-config-global](../images/git-config-global.png "Set global git configuration properties")](/git-foundations/images/git-config-global.png){target=_blank}
 
     ---
 
@@ -82,7 +82,7 @@ For the purpose of familiarization with the process to configure different Git c
     cat ~/.gitconfig
     ```
 
-    ![container-cat-git-global](../images/container-cat-git-global.png "Review global git configuration")
+    [![container-cat-git-global](../images/container-cat-git-global.png "Review global git configuration")](/git-foundations/images/container-cat-git-global.png){target=_blank}
 
 6. Notice the **name** and **email** which values are part of the Git **global** configuration file. Right now, these settings apply to all Git repositories for our current user profile. Effectively, this is all of the repositories in our Docker environment, which means the Git **system** configuration settings no longer apply.
 
@@ -97,7 +97,7 @@ For the purpose of familiarization with the process to configure different Git c
     # Replace 'Your Name' with your first/last name
     ```
 
-    ![git-config-repo](../images/git-config-repo.png "Set repository git configuration properties")
+    [![git-config-repo](../images/git-config-repo.png "Set repository git configuration properties")](/git-foundations/images/git-config-repo.png){target=_blank}
 
     ---
 
@@ -108,7 +108,7 @@ For the purpose of familiarization with the process to configure different Git c
     cat .git/config
     ```
 
-    ![container-cat-git-repo](../images/container-cat-git-repo.png "Review global git configuration")
+    [![container-cat-git-repo](../images/container-cat-git-repo.png "Review global git configuration")](/git-foundations/images/container-cat-git-repo.png){target=_blank}
 
 9. Notice there is a **name** value but no **email** value in the **local repository** configuration file.
 
@@ -133,7 +133,7 @@ For the purpose of familiarization with the process to configure different Git c
     git config user.email
     ```
 
-    ![git-config-repo-check](../images/git-config-repo-check.png "Review effective git configuration settings")
+    [![git-config-repo-check](../images/git-config-repo-check.png "Review effective git configuration settings")](/git-foundations/images/git-config-repo-check.png){target=_blank}
 
 2. We set a **user.name** value within the **local repository** and Git returns that value (notice the **repo** name suffix). Since we didn't set a local repository email, Git looks to the next higher level configuration file, the **global** Git configuration file, for an email address and displays that address.
 
@@ -161,7 +161,7 @@ For the purpose of familiarization with the process to configure different Git c
     git config user.email
     ```
 
-    ![git-config-global-check](../images/git-config-global-check.png "Review effective git configuration settings in a different directory")
+    [![git-config-global-check](../images/git-config-global-check.png "Review effective git configuration settings in a different directory")](/git-foundations/images/git-config-global-check.png){target=_blank}
 
 4. Outside our repository directory we see the both the **user.name** and **user.email** values come from the **global** configuration file (notice the **Global** suffix after the **username**).
 
@@ -179,7 +179,7 @@ For the purpose of familiarization with the process to configure different Git c
     pwd
     ```
 
-    ![container-cd-repo-1](../images/container-cd-repo-1.png "Return to the git repository directory")
+    [![container-cd-repo-1](../images/container-cd-repo-1.png "Return to the git repository directory")](/git-foundations/images/container-cd-repo-1.png){target=_blank}
 
 ---
 

--- a/docs/sections/section_7.md
+++ b/docs/sections/section_7.md
@@ -13,7 +13,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     git branch
     ```
 
-    ![git-branch-1](../images/git-branch-1.png "Display local git branches")
+    [![git-branch-1](../images/git-branch-1.png "Display local git branches")](/git-foundations/images/git-branch-1.png){target=_blank}
 
 2. Notice that only the **main** branch cloned to your local Git repository from GitHub.
 
@@ -29,7 +29,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     git branch -a
     ```
 
-    ![git-branch-a-1](../images/git-branch-a-1.png "Display all local and remote git repository branches")
+    [![git-branch-a-1](../images/git-branch-a-1.png "Display all local and remote git repository branches")](/git-foundations/images/git-branch-a-1.png){target=_blank}
 
 4. Notice how we see:
     - A **main** branch.
@@ -51,7 +51,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     git branch branch2
     ```
 
-    ![git-branch-branch2](../images/git-branch-branch2.png "Create a new local branch named 'branch2'")
+    [![git-branch-branch2](../images/git-branch-branch2.png "Create a new local branch named 'branch2'")](/git-foundations/images/git-branch-branch2.png){target=_blank}
 
     ---
 
@@ -62,7 +62,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     git branch
     ```
 
-    ![git-branch-2](../images/git-branch-2.png "Display all local git branches")
+    [![git-branch-2](../images/git-branch-2.png "Display all local git branches")](/git-foundations/images/git-branch-2.png){target=_blank}
 
 7. Notice your new branch, **branch2** and also that the asterisk next to **main** tells us that, even though we just created **branch2**, our working branch is still **main**.
 
@@ -75,7 +75,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     git branch -a
     ```
 
-    ![git-branch-a-2](../images/git-branch-a-2.png "Display all local and remote git repository branches")
+    [![git-branch-a-2](../images/git-branch-a-2.png "Display all local and remote git repository branches")](/git-foundations/images/git-branch-a-2.png){target=_blank}
 
 9. Notice that **branch2** does not exist as a remote branch in GitHub. This is normal behavior and something we will work with later on.
 
@@ -88,7 +88,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     git checkout branch2
     ```
 
-    ![git-checkout-branch2](../images/git-checkout-branch2.png "Switch to branch 'branch2'")
+    [![git-checkout-branch2](../images/git-checkout-branch2.png "Switch to branch 'branch2'")](/git-foundations/images/git-checkout-branch2.png){target=_blank}
 
     ---
 
@@ -99,7 +99,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     git branch
     ```
 
-    ![git-branch-3](../images/git-branch-3.png "Display local git branches")
+    [![git-branch-3](../images/git-branch-3.png "Display local git branches")](/git-foundations/images/git-branch-3.png){target=_blank}
 
 12. Notice the asterisk next to **branch2** which indicates that **branch2** is our current, working branch.
 
@@ -112,7 +112,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     git checkout -b branch3
     ```
 
-    ![git-checkout-b-branch3](../images/git-checkout-b-branch3.png "Create and switch to a new branch named 'branch3'")
+    [![git-checkout-b-branch3](../images/git-checkout-b-branch3.png "Create and switch to a new branch named 'branch3'")](/git-foundations/images/git-checkout-b-branch3.png){target=_blank}
 
 14. The `git checkout` command allows you to switch between branches.
     - The `git checkout` command with the `-b` flag creates a new branch _and_ switches to the new branch.
@@ -129,7 +129,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     git branch
     ```
 
-    ![git-branch-4](../images/git-branch-4.png "Display local git branches")
+    [![git-branch-4](../images/git-branch-4.png "Display local git branches")](/git-foundations/images/git-branch-4.png){target=_blank}
 
 16. Notice the asterisk next to **branch3** which indicates that **branch3** is our current, working branch.
 
@@ -145,7 +145,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     !!! tip
         Git will not allow you to delete your current, working branch.
 
-    ![git-branch-d-branch2](../images/git-branch-d-branch2.png "Delete branch 'branch2'")
+    [![git-branch-d-branch2](../images/git-branch-d-branch2.png "Delete branch 'branch2'")](/git-foundations/images/git-branch-d-branch2.png){target=_blank}
 
     ---
 
@@ -156,7 +156,7 @@ Our Git environment is ready for us to start work on our repository. Typically, 
     git branch
     ```
 
-    ![git-branch-5](../images/git-branch-5.png "Display local git branches")
+    [![git-branch-5](../images/git-branch-5.png "Display local git branches")](/git-foundations/images/git-branch-5.png){target=_blank}
 
 19. Notice that **branch2** is no longer available.
 

--- a/docs/sections/section_8.md
+++ b/docs/sections/section_8.md
@@ -13,7 +13,7 @@ Let's make a change to one of the files in our local Git repository and see how 
     git status
     ```
 
-    ![git-status-1](../images/git-status-1.png "Display the git repository status")
+    [![git-status-1](../images/git-status-1.png "Display the git repository status")](/git-foundations/images/git-status-1.png){target=_blank}
 
 2. Notice your working branch is **branch3** and that you have no changes to commit (indicated by the `nothing to commit` output.
 
@@ -26,7 +26,7 @@ Let's make a change to one of the files in our local Git repository and see how 
     echo 'This is a new line in the README.md file' >> README.md
     ```
 
-    ![container-echo-readme](../images/container-echo-readme.png "Add a new line of text to 'README.md'")
+    [![container-echo-readme](../images/container-echo-readme.png "Add a new line of text to 'README.md'")](/git-foundations/images/container-echo-readme.png){target=_blank}
 
     ---
 
@@ -37,7 +37,7 @@ Let's make a change to one of the files in our local Git repository and see how 
     git diff
     ```
 
-    ![git-diff-readme-1](../images/git-diff-readme-1.png "Display changes between the working and committed copies of 'README.md'")
+    [![git-diff-readme-1](../images/git-diff-readme-1.png "Display changes between the working and committed copies of 'README.md'")](/git-foundations/images/git-diff-readme-1.png){target=_blank}
 
 5. Notice the `+` character next to the last line in the `git diff` output.  This indicates the a change between the **README.md** file in the working directory and the copy of **README.md** which is already in (committed to) the local Git repository.
 
@@ -50,7 +50,7 @@ Let's make a change to one of the files in our local Git repository and see how 
     git status
     ```
 
-    ![git-status-2](../images/git-status-2.png "Display the git repository status")
+    [![git-status-2](../images/git-status-2.png "Display the git repository status")](/git-foundations/images/git-status-2.png){target=_blank}
 
 7. Notice the **README.md** file in the section, `Changes not staged for commit`.
 

--- a/docs/sections/section_9.md
+++ b/docs/sections/section_9.md
@@ -26,7 +26,7 @@ It is possible to commit many changes to a single file at once although doing so
     git status
     ```
 
-    ![container-touch-my_script](../images/container-touch-my_script.png "Create a new Python script file")
+    [![container-touch-my_script](../images/container-touch-my_script.png "Create a new Python script file")](/git-foundations/images/container-touch-my_script.png){target=_blank}
 
 2. Notice the following:
     - The **my_script.py** file exists and is empty (0 bytes).
@@ -51,7 +51,7 @@ It is possible to commit many changes to a single file at once although doing so
     git status
     ```
 
-    ![git-add-my-script](../images/git-add-my-script.png "Add 'my_script.py' to the staging area")
+    [![git-add-my-script](../images/git-add-my-script.png "Add 'my_script.py' to the staging area")](/git-foundations/images/git-add-my-script.png){target=_blank}
 
 4. Notice that the **my_script.py** file is now in the `Changes to be committed` section.
     - This indicates **my_script.py** is in the Git **staging area**.
@@ -83,7 +83,7 @@ It is possible to commit many changes to a single file at once although doing so
     git status
     ```
 
-    ![git-commit-my-script](../images/git-commit-my-script.png "Commit 'my_script.py' to the local repository")
+    [![git-commit-my-script](../images/git-commit-my-script.png "Commit 'my_script.py' to the local repository")](/git-foundations/images/git-commit-my-script.png){target=_blank}
 
 6. Notice there are no changes to commit. The **README.md** file does have changes although isn't yet staged for commit, we will work on that shortly.
 
@@ -101,7 +101,7 @@ It is possible to commit many changes to a single file at once although doing so
     echo 'print(f"It is nice to meet you, {name})' >> my_script.py
     ```
 
-    ![container-echo-my-script](../images/container-echo-my-script.png "Add code to 'my_script.py'")
+    [![container-echo-my-script](../images/container-echo-my-script.png "Add code to 'my_script.py'")](/git-foundations/images/container-echo-my-script.png){target=_blank}
 
     ---
 
@@ -112,7 +112,7 @@ It is possible to commit many changes to a single file at once although doing so
     git diff
     ```
 
-    ![git-diff-my-script](../images/git-diff-my-script.png "Display changes between the working and committed copies of 'my_script.py'")
+    [![git-diff-my-script](../images/git-diff-my-script.png "Display changes between the working and committed copies of 'my_script.py'")](/git-foundations/images/git-diff-my-script.png){target=_blank}
 
 3. Notice the `+` characters next to the last four lines in the `git diff` output.  This indicates four lines of changes between the **my_script.py** file in the working directory and the copy of **my_script.py** which is already in (committed to) the local Git repository.
 
@@ -125,7 +125,7 @@ It is possible to commit many changes to a single file at once although doing so
     git status
     ```
 
-    ![git-status-3](../images/git-status-3.png "Display the git repository status")
+    [![git-status-3](../images/git-status-3.png "Display the git repository status")](/git-foundations/images/git-status-3.png){target=_blank}
 
     ---
 
@@ -152,7 +152,7 @@ It is possible to commit many changes to a single file at once although doing so
     git commit -m "Appended line to README.md and added commands to my_script.py"
     ```
 
-    ![git-add-all](../images/git-add-all.png "Stage and commit 'my_script.py' and 'README.md' to the repository")
+    [![git-add-all](../images/git-add-all.png "Stage and commit 'my_script.py' and 'README.md' to the repository")](/git-foundations/images/git-add-all.png){target=_blank}
 
 6. Notice the output from the `git status` command shows two files in the staging area, in the `Changes to be committed` section of the output.
 
@@ -167,7 +167,7 @@ It is possible to commit many changes to a single file at once although doing so
     git status
     ```
 
-    ![git-status-4](../images/git-status-4.png "Display the git repository status")
+    [![git-status-4](../images/git-status-4.png "Display the git repository status")](/git-foundations/images/git-status-4.png){target=_blank}
 
 9. Notice the working branch, **branch3** shows no changes to commit.
 
@@ -180,7 +180,7 @@ It is possible to commit many changes to a single file at once although doing so
     git log
     ```
 
-    ![git-log](../images/git-log.png "Display the git commit history")
+    [![git-log](../images/git-log.png "Display the git commit history")](/git-foundations/images/git-log.png){target=_blank}
 
 11. Notice how information about the most recent commit is at the top of the `git log` output, and how the **commit messages** for each commit in the log provide important information about the changes a particular commit includes.  This is one reason descriptive commit messages are important.
 
@@ -198,7 +198,7 @@ It is possible to commit many changes to a single file at once although doing so
     git remote --verbose
     ```
 
-    ![git-remote-verbose](../images/git-remote-verbose.png "Display the remote repository URL")
+    [![git-remote-verbose](../images/git-remote-verbose.png "Display the remote repository URL")](/git-foundations/images/git-remote-verbose.png){target=_blank}
 
     ---
 
@@ -209,7 +209,7 @@ It is possible to commit many changes to a single file at once although doing so
     git push
     ```
 
-    ![git-push-1](../images/git-push-1.png "Push local repository changes to GitHub")
+    [![git-push-1](../images/git-push-1.png "Push local repository changes to GitHub")](/git-foundations/images/git-push-1.png){target=_blank}
 
 3. Notice that we receive a `fatal` error message when we attempt to use the `git push` command. GitHub does not have a branch which matches the working branch in our local repository (**branch3**) and, therefore, returns an error.
     - Before we can push changes with a simple `git push` command, we need to create **branch3** in GitHub.
@@ -224,7 +224,7 @@ It is possible to commit many changes to a single file at once although doing so
     git push --set-upstream origin branch3
     ```
 
-    ![git-push-set-upstream](../images/git-push-set-upstream.png "Display the remote repository URL and create a remote branch named 'branch3'")
+    [![git-push-set-upstream](../images/git-push-set-upstream.png "Display the remote repository URL and create a remote branch named 'branch3'")](/git-foundations/images/git-push-set-upstream.png){target=_blank}
 
 5. Notice that Git creates a new branch, **branch3**, in GitHub, and pushes the local Git repository **branch3** commits to the new GitHub **branch3**.
 


### PR DESCRIPTION
The images render at a size which makes them difficult to read.  Setting an anchor and a target of the raw image in GitHub will allow viewing of images at their full size in a new tab.

Closes #22 