### PR TITLE
Remove pull-request event trigger

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -7,8 +7,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Removing the **pull-request** event trigger so that _opening_ a PR does not trigger an automatic mkdocs build/deploy.  There is an activity filter for **closed** pull-request events which limits the pull-request scope to closed PRs although that filter will trigger a build/deploy whenever a PR closes, whether or not the code is merged.

The existing action syntax uses the **push** event for the **main** branch which, if I understand correctly means any **merge** action to **main** will build/deploy mkdocs.  If merging a PR counts as a **push** event, removing the **pull-request** event trigger and leaving the existing syntax should create the desired behavior; to only build/deploy mkdocs when someone approves and merges a PR.  Branch protection is on for the **main** branch in order to block direct push/merge events.

```yaml
on:
  push:
    branches: [ main ]
```

Closes #26 